### PR TITLE
chore: simplify PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,31 +2,7 @@
 
 Thanks for creating this pull request!
 
-Please make sure you provide the relevant context.
+Please make sure to link the issue you are closing as "Closes #issueNr". 
+This helps us to understand the context of this PR.
 
 -->
-
-__Which issue does this PR address?__
-
-Closes #
-
-__Acceptance Criteria__
-
-<!--
-
-Link the acceptance criteria here if they are defined.
-
--->
-
-* [ ] Corresponds to the concept <!-- link document here -->
-* [ ] Corresponds to the design <!-- link document here -->
-
-__Definition of Done__
-
-* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
-* [ ] corresponds to [the code standards](https://github.com/bpmn-io/.github/blob/master/.github/CONTRIBUTING.md#create-a-pull-request)
-* [ ] passes Continuous Integration checks
-* [ ] available as feature branch on GitHub
-  * [ ] contains the cleaned up commit history
-  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
-  * [ ] a single commit closes the issue via Closes #issuenr


### PR DESCRIPTION
This simplifies our existing PULL_REQUEST_TEMPLATE to a point where it may not be ignored, but considered.

I believe this is fine. We do not receive a not of external pull requests and GitHub is great with linking additional resources, for example Contributing Guidelines for everyone interested to have a look.