### PR TITLE
chore(PULL_REQUEST_TEMPLATE): rework guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@ To ensure you provided everything we need to look at your PR:
 * [ ] **Brief textual description** of the changes present
 * [ ] **Visual demo** attached
 * [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
-* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to  {LINK_TO_ISSUE}`
+* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
 
 <!--
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@ To ensure you provided everything we need to look at your PR:
 * [ ] **Brief textual description** of the changes present
 * [ ] **Visual demo** attached
 * [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
-* [ ] Closed or related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to  {LINK_TO_ISSUE}`
+* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to  {LINK_TO_ISSUE}`
 
 <!--
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,24 @@
+### Proposed Changes
+
 <!--
 
-Thanks for creating this pull request!
+Add relevant context (issue fixed or related to), 
+a capture of the UI changes (if any) as well as 
+steps to try out your changes.
 
-Please make sure to link the issue you are closing as "Closes #issueNr". 
-This helps us to understand the context of this PR.
+--> 
+
+### Checklist
+
+To ensure you provided everything we need to look at your PR:
+
+* [ ] **Brief textual description** of the changes present
+* [ ] **Visual demo** attached
+* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
+* [ ] Closed or related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to  {LINK_TO_ISSUE}`
+
+<!--
+
+Thanks for creating this pull request! ❤️
 
 -->


### PR DESCRIPTION
This adds additional (sensible) structure to our PR template, as discussed in prior sessions:

![image](https://github.com/bpmn-io/.github/assets/58601/60a24c1e-aab6-4739-9cb1-e7b00cfa80ed)

What I'd like to accomplish is that we _consistently_ link what is needed from within the PRs, and _establish relevant context_. 