### PR TITLE
chore: add organizational `AGENTS.md` file

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -52,7 +52,7 @@ npm run all
 
 * Avoid extensive mocking and stubbing; prefer simple environment setup and validate behaviors at the appropriate level, including good unit tests where useful and reasonably "end-to-end" tests where appropriate
 * Look towards existing test patterns, re-use them
-* When in doubt, then create tests first ("test driven") before implementing
+* When in doubt, create tests first ("test-driven") before implementing
 * Follow good testing practices: Every test is clearly structured as `given (-> assume) -> when -> then`
   ```javascript
   // given

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -82,7 +82,7 @@ An implementation is ready for review when it is:
 * Contribution is semantically structured in relevant commits
   * No work in progress - squash things together for a clean and understandable history
 * Clearly separate feature / fix and additional refactorings
-* One commit close linked issue with `Closes #<issue>`
+* Exactly one commit should close the linked issue with `Closes #<issue>`
 * Breaking changes must be indicated in the commit message
 * Push to a feature branch on GitHub
 

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -62,7 +62,7 @@ npm run all
   someBehaviorToTest();
 
   // then
-  // optional description what is asserted here
+  // optional description of what is asserted here
   expect(otherThing).to.exist;
   expect(otherThing).to.equal(expectedThing);
   ```

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -12,7 +12,7 @@ Types of changes you will work on:
 - **Foundational change:** Changes to core architecture or domain model that force many modules, APIs, and behaviors to be reconsidered.
 
 Before implementing every change:
-- Verify you have sufficient understanding what has to be changed
+- Verify you have sufficient understanding of what has to be changed
 - Define what type of change this is (linear, structural, foundational)
 - Make a plan for it
 

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -9,7 +9,7 @@ You are the maintainer of this repo. Fix defects at their source — don't work 
 Types of changes you will work on:
 - **Linear change:** Small, isolated edits that don't introduce new concepts or alter interfaces.
 - **Structural change:** Refactors that change module boundaries, APIs, data flows, or responsibilities while keeping overall behavior and architecture intact.
-- **Foundational change:** Changes to core architecture, domain model that force many modules, APIs, and behaviors to be reconsidered.
+- **Foundational change:** Changes to core architecture or domain model that force many modules, APIs, and behaviors to be reconsidered.
 
 Before implementing every change:
 - Verify you have sufficient understanding what has to be changed

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,98 @@
+# bpmn-io Development Instructions for Agents
+
+## Role
+
+You are the maintainer of this repo. Fix defects at their source — don't work around them.
+
+## Your work
+
+Types of changes you will work on:
+- **Linear change:** Small, isolated edits that don't introduce new concepts or alter interfaces.
+- **Structural change:** Refactors that change module boundaries, APIs, data flows, or responsibilities while keeping overall behavior and architecture intact.
+- **Foundational change:** Changes to core architecture, domain model that force many modules, APIs, and behaviors to be reconsidered.
+
+Before implementing every change:
+- Verify you have sufficient understanding what has to be changed
+- Define what type of change this is (linear, structural, foundational)
+- Make a plan for it
+
+## Project Setup
+
+We use `node@24` in our projects - ensure you have it installed.
+
+Install project, including all dependencies via
+
+```
+npm install
+```
+
+## Build & Test
+
+Run the full build (lint + tests) before considering work done:
+
+```
+npm run all
+```
+
+## Code Style
+
+* Spaces instead of tabs; single-quotes
+* Lint rules are enforced via [`eslint-plugin-bpmn-io`](https://github.com/bpmn-io/eslint-plugin-bpmn-io)
+* Verify locally with `npm run lint`
+* If in doubt, follow local code style
+
+## Documentation
+
+* Functions have JSDoc documentation, especially public API
+* Documentation of API does not focus on the HOW, but the what, the purpose of the function
+* Key parts of more complex algorithms are documented using local, inline comments
+* DO NOT be overly verbose - what is obvious from source code does not have to be explained
+
+## Testing
+
+* Avoid extensive mocking and stubbing; prefer simple environment setup and validate behaviors at the appropriate level, including good unit tests where useful and reasonably "end-to-end" tests where appropriate
+* Look towards existing test patterns, re-use them
+* When in doubt, then create tests first ("test driven") before implementing
+* Follow good testing practices: Every test is clearly structured as `given (-> assume) -> when -> then`
+  ```javascript
+  // given
+  someSetup();
+
+  // when
+  someBehaviorToTest();
+
+  // then
+  // optional description what is asserted here
+  expect(otherThing).to.exist;
+  expect(otherThing).to.equal(expectedThing);
+  ```
+
+## Definition of Done
+
+An implementation is ready for review when it is:
+
+* **Working** — usable, fits with existing functionality, discoverable if it is a new feature
+* **Clean** — simple solution, understandable code, no leftover code, uses existing patterns
+* **Tested** — sufficiently covered by [good tests](#testing)
+* **CI green** — `npm run all` passes
+
+## Commits & Branch
+
+* Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
+* Contribution is semantically structured in relevant commits
+  * No work in progress - squash things together for a clean and understandable history
+* Clearly separate feature / fix and additional refactorings
+* One commit close linked issue with `Closes #<issue>`
+* Breaking changes must be indicated in the commit message
+* Push to a feature branch on GitHub
+
+## Pull Request
+
+Every PR must use our pull request template - find it either in the project repo or in the organizational `.github` repo at `.github/PULL_REQUEST_TEMPLATE.md`, and provide the relevant information.
+
+Ensure the PR provides essential context for reviewers:
+
+* Link to the related issue (`Closes #<issue>` or `Related to #<issue>`)
+* Brief description of the changes, including the WHAT and WHY
+* Screenshots or short video for any UI/UX changes
+* Steps to try out the changes (e.g. using [`@bpmn-io/sr`](https://github.com/bpmn-io/sr))


### PR DESCRIPTION
### Proposed Changes

Add an `AGENTS.md` file to guide agents in contributing to our projects.

This is in essence a condensed version of our good practices (both `definition of done` and `contributing` - it also incorporates [Camunda ideas](https://raw.githubusercontent.com/camunda/.github/refs/heads/main/AGENTS.md).

Related to https://github.com/bpmn-io/internal-docs/issues/1244

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
